### PR TITLE
Fix layout empty

### DIFF
--- a/app/code/community/SomethingDigital/Modal/Block/Modal.php
+++ b/app/code/community/SomethingDigital/Modal/Block/Modal.php
@@ -12,6 +12,9 @@ class SomethingDigital_Modal_Block_Modal extends Mage_Core_Block_Template
     public function getModalContent() 
     {
         $blockId = $this->getConfig('block');
+        if(!$this->getLayout()) {
+            return;
+        }
         $output = $this->getLayout()->createBlock('cms/block')->setBlockId($blockId)->toHtml();
         return str_replace(array("\r", "\n"), "", addslashes($output));
     }


### PR DESCRIPTION
On CFFG, we are seeing an error in the magento error log

```
From the php log:

error.log:[07-Aug-2017 07:45:53] WARNING: [pool default] child 3963 said into stderr: "NOTICE:
 PHP message: PHP Fatal error:  Call to a member function createBlock() on null in 
/var/www/vhosts/staging.chesapeake.com/releases/20170802215819/app/code/community/Somethi
ngDigital/Modal/Block/Modal.php on line 15"
```

This is to add a condition, which avoids calling the createBlock when the getLayout() is null